### PR TITLE
Remove custom code-sign Entitlements.plist

### DIFF
--- a/IndoorRouting.sln
+++ b/IndoorRouting.sln
@@ -44,30 +44,10 @@ Global
 	GlobalSection(MonoDevelopProperties) = preSolution
 		Policies = $0
 		$0.TextStylePolicy = $1
-		$1.FileWidth = 120
-		$1.inheritsSet = VisualStudio
-		$1.inheritsScope = text/plain
 		$1.scope = text/x-csharp
+		$1.TabsToSpaces = True
 		$0.CSharpFormattingPolicy = $2
-		$2.IndentSwitchSection = True
-		$2.NewLinesForBracesInProperties = True
-		$2.NewLinesForBracesInAccessors = True
-		$2.NewLinesForBracesInAnonymousMethods = True
-		$2.NewLinesForBracesInControlBlocks = True
-		$2.NewLinesForBracesInAnonymousTypes = True
-		$2.NewLinesForBracesInObjectCollectionArrayInitializers = True
-		$2.NewLinesForBracesInLambdaExpressionBody = True
-		$2.NewLineForElse = True
-		$2.NewLineForCatch = True
-		$2.NewLineForFinally = True
-		$2.NewLineForMembersInObjectInit = True
-		$2.NewLineForMembersInAnonymousTypes = True
-		$2.NewLineForClausesInQuery = True
-		$2.SpacingAfterMethodDeclarationName = False
-		$2.SpaceAfterMethodCallName = False
-		$2.SpaceBeforeOpenSquareBracket = False
-		$2.inheritsSet = Mono
-		$2.inheritsScope = text/x-csharp
 		$2.scope = text/x-csharp
+		version = 2.0.1
 	EndGlobalSection
 EndGlobal

--- a/IndoorRouting/IndoorRouting.shproj
+++ b/IndoorRouting/IndoorRouting.shproj
@@ -2,6 +2,7 @@
 <Project ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <PropertyGroup>
     <ProjectGuid>{C74E25B9-776D-4522-891F-660D1A128785}</ProjectGuid>
+    <ReleaseVersion>2.0.1</ReleaseVersion>
   </PropertyGroup>
   <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
   <Import Project="$(MSBuildExtensionsPath32)\Microsoft\VisualStudio\v$(VisualStudioVersion)\CodeSharing\Microsoft.CodeSharing.Common.Default.props" />

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,5 +1,11 @@
 # Release notes
 
+## Release 2.0.1
+
+Changes:
+
+* Removes custom code-sign empty Entitlements.plist
+
 ## Release 2.0
 
 Changes:

--- a/iOS/IndoorRouting.iOS.csproj
+++ b/iOS/IndoorRouting.iOS.csproj
@@ -11,6 +11,7 @@
     <IPhoneResourcePrefix>Resources</IPhoneResourcePrefix>
     <NuGetPackageImportStamp>
     </NuGetPackageImportStamp>
+    <ReleaseVersion>2.0.1</ReleaseVersion>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|iPhoneSimulator' ">
     <DebugSymbols>true</DebugSymbols>

--- a/iOS/IndoorRouting.iOS.csproj
+++ b/iOS/IndoorRouting.iOS.csproj
@@ -30,7 +30,6 @@
     <PlatformTarget>x64</PlatformTarget>
     <MtouchExtraArgs>
     </MtouchExtraArgs>
-    <CodesignEntitlements>Entitlements.plist</CodesignEntitlements>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|iPhone' ">
     <DebugType>pdbonly</DebugType>

--- a/iOS/Info.plist
+++ b/iOS/Info.plist
@@ -7,9 +7,9 @@
 	<key>CFBundleIdentifier</key>
 	<string>com.esri.arcgisruntime.opensourceapps.indoorrouting.xamarin</string>
 	<key>CFBundleShortVersionString</key>
-	<string>2.0</string>
+	<string>2.0.1</string>
 	<key>CFBundleVersion</key>
-	<string>2.0</string>
+	<string>2.0.1</string>
 	<key>LSRequiresIPhoneOS</key>
 	<true/>
 	<key>MinimumOSVersion</key>


### PR DESCRIPTION
Currently, the iOS project attempts to sign the code with a custom Entitlements.plist object. This Entitlements.plist object is blank and thus VS can't sign the project and and the build errors out.

This PR removes the custom code-sign step. This makes building the project in development for simulator, easy.

I'm not sure if this is the best technique for solving this problem. I'm also not sure if i've properly incremented the patch version number. I'm also not intending to introduce formatting changes to the global project, they were generated automatically. Feel free to outright reject this PR if it does not serve the project.

The current build error.

```

Building IndoorRouting.iOS (Debug)
Build started 7/16/2020 2:53:34 PM.
__________________________________________________
Project "/Users/eli9422/Documents/runtime/example/indoor-routing/dotnet/indoor-routing-xamarin/iOS/IndoorRouting.iOS.csproj" (Build target(s)):

Target _BeforeCoreCompileInterfaceDefinitions:
  Skipping target "_BeforeCoreCompileInterfaceDefinitions" because all output files are up-to-date with respect to the input files.
Target _CoreCompileInterfaceDefinitions:
  Skipping target "_CoreCompileInterfaceDefinitions" because all output files are up-to-date with respect to the input files.
Target _BeforeCoreCompileImageAssets:
  Skipping target "_BeforeCoreCompileImageAssets" because all output files are up-to-date with respect to the input files.
Target _CoreCompileImageAssets:
  Skipping target "_CoreCompileImageAssets" because all output files are up-to-date with respect to the input files.
Target _CoreCompileColladaAssets:
  Skipping target "_CoreCompileColladaAssets" because it has no inputs.
Target _BeforeCoreCompileSceneKitAssets:
  Skipping target "_BeforeCoreCompileSceneKitAssets" because it has no inputs.
Target _BeforeCoreCompileSceneKitAssets:
  Skipping target "_BeforeCoreCompileSceneKitAssets" because it has no inputs.
Target _BeforeCoreCompileSceneKitAssets:
  Skipping target "_BeforeCoreCompileSceneKitAssets" because it has no inputs.
Target _CoreCompileSceneKitAssets:
  Skipping target "_CoreCompileSceneKitAssets" because it has no inputs.
Target _BeforeCompileTextureAtlases:
  Skipping target "_BeforeCompileTextureAtlases" because it has no inputs.
Target _BeforeCompileTextureAtlases:
  Skipping target "_BeforeCompileTextureAtlases" because it has no inputs.
Target _BeforeCompileTextureAtlases:
  Skipping target "_BeforeCompileTextureAtlases" because it has no inputs.
Target _CoreCompileTextureAtlases:
  Skipping target "_CoreCompileTextureAtlases" because it has no inputs.
Target _BeforeCompileCoreMLModels:
  Skipping target "_BeforeCompileCoreMLModels" because all output files are up-to-date with respect to the input files.
Target _CoreCompileCoreMLModels:
  Skipping target "_CoreCompileCoreMLModels" because all output files are up-to-date with respect to the input files.
Target _CoreOptimizePngImages:
  Skipping target "_CoreOptimizePngImages" because it has no outputs.
Target _CoreOptimizePropertyLists:
  Skipping target "_CoreOptimizePropertyLists" because it has no inputs.
Target _CoreOptimizeLocalizationFiles:
  Skipping target "_CoreOptimizeLocalizationFiles" because all output files are up-to-date with respect to the input files.
Target GenerateTargetFrameworkMonikerAttribute:
  Skipping target "GenerateTargetFrameworkMonikerAttribute" because all output files are up-to-date with respect to the input files.
Target CoreCompile:
  Skipping target "CoreCompile" because all output files are up-to-date with respect to the input files.
Target _CopyFilesMarkedCopyLocal:
    Touching "/Users/eli9422/Documents/runtime/example/indoor-routing/dotnet/indoor-routing-xamarin/iOS/obj/iPhoneSimulator/Debug/IndoorRouting.iOS.csproj.CopyComplete".
Target CopyFilesToOutputDirectory:
    IndoorRouting.iOS -> /Users/eli9422/Documents/runtime/example/indoor-routing/dotnet/indoor-routing-xamarin/iOS/bin/iPhoneSimulator/Debug/Esri.ArcGISRuntime.OpenSourceApps.IndoorRouting.Xamarin.exe
Target _DetectSigningIdentity:
    /Library/Frameworks/Mono.framework/External/xbuild/Xamarin/iOS/Xamarin.iOS.Common.targets(693,3): error : Could not find any available provisioning profiles for Esri.ArcGISRuntime.OpenSourceApps.IndoorRouting.Xamarin on iOS.
Done building target "_DetectSigningIdentity" in project "IndoorRouting.iOS.csproj" -- FAILED.

Done building project "IndoorRouting.iOS.csproj" -- FAILED.

Build FAILED.

/Library/Frameworks/Mono.framework/External/xbuild/Xamarin/iOS/Xamarin.iOS.Common.targets(693,3): error : Could not find any available provisioning profiles for Esri.ArcGISRuntime.OpenSourceApps.IndoorRouting.Xamarin on iOS.
    0 Warning(s)
    1 Error(s)

Time Elapsed 00:00:00.25

========== Build: 0 succeeded, 1 failed, 1 up-to-date, 0 skipped ==========

Build: 1 error, 0 warnings
```