### PR TITLE
Updates for 100.10

### DIFF
--- a/IndoorRouting.sln
+++ b/IndoorRouting.sln
@@ -48,6 +48,6 @@ Global
 		$1.TabsToSpaces = True
 		$0.CSharpFormattingPolicy = $2
 		$2.scope = text/x-csharp
-		version = 2.0.4
+		version = 2.0.5
 	EndGlobalSection
 EndGlobal

--- a/IndoorRouting/IndoorRouting.shproj
+++ b/IndoorRouting/IndoorRouting.shproj
@@ -2,7 +2,7 @@
 <Project ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <PropertyGroup>
     <ProjectGuid>{C74E25B9-776D-4522-891F-660D1A128785}</ProjectGuid>
-    <ReleaseVersion>2.0.4</ReleaseVersion>
+    <ReleaseVersion>2.0.5</ReleaseVersion>
   </PropertyGroup>
   <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
   <Import Project="$(MSBuildExtensionsPath32)\Microsoft\VisualStudio\v$(VisualStudioVersion)\CodeSharing\Microsoft.CodeSharing.Common.Default.props" />

--- a/README.md
+++ b/README.md
@@ -67,7 +67,7 @@ If there are changes made in the Original repository, you can sync the fork to k
 
 ## Requirements
 * [ArcGIS Runtime SDK for .NET 100.9 or higher](https://developers.arcgis.com/net/latest/)
-* [XCode 12 or higher](https://developer.apple.com/xcode/downloads/) and the iOS 13 SDK.
+* [Xcode](https://developer.apple.com/xcode/downloads/) and the iOS 13 SDK. The latest version of Xcode is preferred
 * [Visual Studio for Mac - latest](https://visualstudio.microsoft.com/vs/mac/) or [Visual Studio 2017 or higher](https://visualstudio.microsoft.com/vs/whatsnew/)
 
 ## Resources

--- a/README.md
+++ b/README.md
@@ -66,7 +66,7 @@ If there are changes made in the Original repository, you can sync the fork to k
 4. ```git merge upstream/master``` to sync your local `master` branch with `upstream/master`. **Note**: Your local changes will be retained and your fork's master branch will be in sync with the upstream repository.
 
 ## Requirements
-* [ArcGIS Runtime SDK for .NET 100.9 or higher](https://developers.arcgis.com/net/latest/)
+* [ArcGIS Runtime SDK for .NET 100.10 or higher](https://developers.arcgis.com/net/latest/)
 * [Xcode](https://developer.apple.com/xcode/downloads/) and the iOS 13 SDK. The latest version of Xcode is preferred
 * [Visual Studio for Mac - latest](https://visualstudio.microsoft.com/vs/mac/) or [Visual Studio 2017 or higher](https://visualstudio.microsoft.com/vs/whatsnew/)
 

--- a/README.md
+++ b/README.md
@@ -67,8 +67,7 @@ If there are changes made in the Original repository, you can sync the fork to k
 
 ## Requirements
 * [ArcGIS Runtime SDK for .NET 100.9 or higher](https://developers.arcgis.com/net/latest/)
-* [XCode 11 or higher](https://developer.apple.com/xcode/downloads/)
-    * App supports a minimum deployment target of iOS 12 but requires the iOS 13 SDK to build. Note, because ArcGIS Runtime uses [Metal](https://developer.apple.com/metal/), if you want to simulate the app using an iOS simulator you must be running, at minimum, macOS Catalina and iOS 13.
+* [XCode 12 or higher](https://developer.apple.com/xcode/downloads/) and the iOS 13 SDK.
 * [Visual Studio for Mac - latest](https://visualstudio.microsoft.com/vs/mac/) or [Visual Studio 2017 or higher](https://visualstudio.microsoft.com/vs/whatsnew/)
 
 ## Resources

--- a/README.md
+++ b/README.md
@@ -67,7 +67,7 @@ If there are changes made in the Original repository, you can sync the fork to k
 
 ## Requirements
 * [ArcGIS Runtime SDK for .NET 100.10 or higher](https://developers.arcgis.com/net/latest/)
-* [Xcode](https://developer.apple.com/xcode/downloads/) and the iOS 13 SDK. The latest version of Xcode is preferred
+* [Xcode](https://developer.apple.com/xcode/downloads/) and the iOS 13 SDK. Note, the latest version of Xcode is [required](https://docs.microsoft.com/en-us/xamarin/ios/get-started/installation/#required-components) by Xamarin.iOS.
 * [Visual Studio for Mac - latest](https://visualstudio.microsoft.com/vs/mac/) or [Visual Studio 2017 or higher](https://visualstudio.microsoft.com/vs/whatsnew/)
 
 ## Resources

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -5,6 +5,7 @@
 Changes:
 
 * Removes support for iOS 12.
+* Updated to ArcGIS Runtime 100.10.
 
 ## Release 2.0.4
 

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,5 +1,11 @@
 # Release notes
 
+## Release 2.0.5
+
+Changes:
+
+* Removes support for iOS 12, and updates doc to reflect that.
+
 ## Release 2.0.4
 
 Changes:

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -4,7 +4,7 @@
 
 Changes:
 
-* Removes support for iOS 12, and updates doc to reflect that.
+* Removes support for iOS 12.
 
 ## Release 2.0.4
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -419,7 +419,7 @@ iPad (2019):
 
 ## Customize app appearance
 
-To make it easier to update the visual appearance of the app, many values related to the UI are configured in a static `ApplicationTheme` class. You can edit values in that class to update the entire app in a uniform way. Note that some values differ between iOS 12 and later versions, due to limitations in support for dark mode APIs.
+To make it easier to update the visual appearance of the app, many values related to the UI are configured in a static `ApplicationTheme` class. You can edit values in that class to update the entire app in a uniform way.
 
 ```cs
 public static class ApplicationTheme
@@ -456,7 +456,6 @@ public static class ApplicationTheme
         HandlebarCornerRadius = 2;
         CornerRadius = 8;
 
-
         // Accessory button is a light/dark responsive color defined in the asset catalog
         AccessoryButtonColor = UIColor.FromName("AccessoryButtonColor");
         ActionBackgroundColor = AccessoryButtonColor;
@@ -467,25 +466,12 @@ public static class ApplicationTheme
         ActionButtonHeight = 44;
         HeaderFont = UIFont.PreferredTitle1;
 
-        if (UIDevice.CurrentDevice.CheckSystemVersion(13, 0))
-        {
-            BackgroundColor = UIColor.SystemBackgroundColor;
-            ForegroundColor = UIColor.LabelColor;
-            SeparatorColor = UIColor.SystemGray2Color;
-            PanelBackgroundMaterial = UIBlurEffect.FromStyle(UIBlurEffectStyle.SystemMaterial);
-            PrimaryLabelColor = UIColor.LabelColor;
-            SecondaryLabelColor = UIColor.SecondaryLabelColor;
-        }
-        else
-        {
-            BackgroundColor = UIColor.White;
-            ForegroundColor = UIColor.Black;
-            SeparatorColor = UIColor.LightGray;
-            PanelBackgroundMaterial = UIBlurEffect.FromStyle(UIBlurEffectStyle.Prominent);
-            PrimaryLabelColor = UIColor.Black;
-            SecondaryLabelColor = UIColor.DarkGray;
-        }
-
+        BackgroundColor = UIColor.SystemBackgroundColor;
+        ForegroundColor = UIColor.LabelColor;
+        SeparatorColor = UIColor.SystemGray2Color;
+        PanelBackgroundMaterial = UIBlurEffect.FromStyle(UIBlurEffectStyle.SystemMaterial);
+        PrimaryLabelColor = UIColor.LabelColor;
+        SecondaryLabelColor = UIColor.SecondaryLabelColor;
     }
 }
 ```

--- a/iOS/ApplicationTheme.cs
+++ b/iOS/ApplicationTheme.cs
@@ -54,7 +54,6 @@ namespace Esri.ArcGISRuntime.OpenSourceApps.IndoorRouting.iOS
             HandlebarCornerRadius = 2;
             CornerRadius = 8;
             
-
             // Accessory button is a light/dark responsive color defined in the asset catalog
             AccessoryButtonColor = UIColor.FromName("AccessoryButtonColor");
             ActionBackgroundColor = AccessoryButtonColor;
@@ -65,25 +64,12 @@ namespace Esri.ArcGISRuntime.OpenSourceApps.IndoorRouting.iOS
             ActionButtonHeight = 44;
             HeaderFont = UIFont.PreferredTitle1;
 
-            if (UIDevice.CurrentDevice.CheckSystemVersion(13, 0))
-            {
-                BackgroundColor = UIColor.SystemBackgroundColor;
-                ForegroundColor = UIColor.LabelColor;
-                SeparatorColor = UIColor.SystemGray2Color;
-                PanelBackgroundMaterial = UIBlurEffect.FromStyle(UIBlurEffectStyle.SystemMaterial);
-                PrimaryLabelColor = UIColor.LabelColor;
-                SecondaryLabelColor = UIColor.SecondaryLabelColor;
-            }
-            else
-            {
-                BackgroundColor = UIColor.White;
-                ForegroundColor = UIColor.Black;
-                SeparatorColor = UIColor.LightGray;
-                PanelBackgroundMaterial = UIBlurEffect.FromStyle(UIBlurEffectStyle.Prominent);
-                PrimaryLabelColor = UIColor.Black;
-                SecondaryLabelColor = UIColor.DarkGray;
-            }
-            
+            BackgroundColor = UIColor.SystemBackgroundColor;
+            ForegroundColor = UIColor.LabelColor;
+            SeparatorColor = UIColor.SystemGray2Color;
+            PanelBackgroundMaterial = UIBlurEffect.FromStyle(UIBlurEffectStyle.SystemMaterial);
+            PrimaryLabelColor = UIColor.LabelColor;
+            SecondaryLabelColor = UIColor.SecondaryLabelColor;
         }
     }
 }

--- a/iOS/IndoorRouting.iOS.csproj
+++ b/iOS/IndoorRouting.iOS.csproj
@@ -342,13 +342,13 @@
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="Esri.ArcGISRuntime">
-      <Version>100.9.0</Version>
+      <Version>100.10.0</Version>
     </PackageReference>
     <PackageReference Include="Esri.ArcGISRuntime.Xamarin.iOS">
-      <Version>100.9.0</Version>
+      <Version>100.10.0</Version>
     </PackageReference>
     <PackageReference Include="Esri.ArcGISRuntime.Toolkit">
-      <Version>100.9.0</Version>
+      <Version>100.10.0</Version>
     </PackageReference>
   </ItemGroup>
   <ItemGroup />

--- a/iOS/IndoorRouting.iOS.csproj
+++ b/iOS/IndoorRouting.iOS.csproj
@@ -11,7 +11,7 @@
     <IPhoneResourcePrefix>Resources</IPhoneResourcePrefix>
     <NuGetPackageImportStamp>
     </NuGetPackageImportStamp>
-    <ReleaseVersion>2.0.4</ReleaseVersion>
+    <ReleaseVersion>2.0.5</ReleaseVersion>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|iPhoneSimulator' ">
     <DebugSymbols>true</DebugSymbols>

--- a/iOS/Info.plist
+++ b/iOS/Info.plist
@@ -7,13 +7,13 @@
 	<key>CFBundleIdentifier</key>
 	<string>com.esri.arcgisruntime.opensourceapps.indoorrouting.xamarin</string>
 	<key>CFBundleShortVersionString</key>
-	<string>2.0.4</string>
+	<string>2.0.5</string>
 	<key>CFBundleVersion</key>
-	<string>2.0.4</string>
+	<string>2.0.5</string>
 	<key>LSRequiresIPhoneOS</key>
 	<true/>
 	<key>MinimumOSVersion</key>
-	<string>12.0</string>
+	<string>13.0</string>
 	<key>UIDeviceFamily</key>
 	<array>
 		<integer>1</integer>


### PR DESCRIPTION
~With 100.10, iOS 12 will be deprecated. This change removes support for iOS 12 for the dev branch. RT will be updated to 100.10 in a future PR ahead of certification.~

Certification is upon us, so in the interest of efficiency I've added the version bump to this PR.